### PR TITLE
NO JIRA: fix fit_cond

### DIFF
--- a/ow_calibration/brk_pt_fit/brk_pt_fit.py
+++ b/ow_calibration/brk_pt_fit/brk_pt_fit.py
@@ -30,6 +30,7 @@ https://gitlab.noc.soton.ac.uk/edsmall/bodc-dmqc-python
 """
 
 import numpy as np
+import scipy.linalg
 from ow_calibration.sorter.sorter import sorter
 
 
@@ -95,10 +96,11 @@ def brk_pt_fit(x_obvs, y_obvs, w_i, breaks=None):
 
     # calculate fit parameters
     if w_i.__len__() > 0:
-        fit_param = np.linalg.solve(ls_est, np.dot(np.dot(trends.T, w_i), y_obvs))
+        fit_param = np.dot(np.dot(scipy.linalg.solve(ls_est, trends.T), w_i), y_obvs)
 
     else:
-        fit_param = np.linalg.solve(ls_est, np.dot(trends.T, y_obvs))
+        fit_param = scipy.linalg.solve(ls_est, np.dot(trends.T, y_obvs))
+
 
     # calculate fit estimate
     residual = y_obvs - np.dot(trends, fit_param)

--- a/ow_calibration/fit_cond/fit_cond.py
+++ b/ow_calibration/fit_cond/fit_cond.py
@@ -274,7 +274,7 @@ def fit_cond(x, y, n_err, lvcov, *args):
 
     if no_args > 0:
         for n in range(int(no_args / 2)):
-            parm = args[2 * (n - 1)]
+            parm = args[2 *n]
             value = args[(n * 2) + 1]
 
             if not isinstance(parm, str):
@@ -369,7 +369,7 @@ def fit_cond(x, y, n_err, lvcov, *args):
                 print("WARNING: Only have " + str(ndf) + " degrees of freedom")
                 print("Estimate offset only")
 
-    nbr = 1
+    nbr = pbrk
     if nbr == -1:
         # offset only
         # since this is an error weighted average, yx won't necessarily be 0
@@ -432,6 +432,7 @@ def fit_cond(x, y, n_err, lvcov, *args):
             ubrk = optim['x'][0]
             residual = optim['fun']
 
+
         b_pts[0:nbr, nbr] = breaks.T
         b_A[0:nbr + 2, nbr + 1] = A[0:nbr + 2]
         rss[0, nbr + 1] = np.sum(residual ** 2 / err_var)
@@ -450,7 +451,6 @@ def fit_cond(x, y, n_err, lvcov, *args):
         best = np.argmin(aic[0, good])
 
         if isinstance(good, np.ndarray):
-            input("***")
             best = good[best] + 1
         else:
             best = good + 1
@@ -558,6 +558,9 @@ def fit_cond(x, y, n_err, lvcov, *args):
             elif setbreaks:
                 # E stays fixed if breaks are specified
                 A, residual = brk_pt_fit(xf, yf, w_i, breaks)
+                print(A)
+                print(residual)
+                input("**")
 
             else:
                 # give an initial guess as the fitted break points to speed up calculation
@@ -657,8 +660,8 @@ def fit_cond(x, y, n_err, lvcov, *args):
         time_deriv_err = P_2[1] * np.ones((nfit, 1))
 
     else:
-        time_deriv = np.ones((best, 1)) * np.nan
-        time_deriv_err = np.ones((best, 1)) * np.nan
+        time_deriv = np.ones((nfit, 1)) * np.nan
+        time_deriv_err = np.ones((nfit, 1)) * np.nan
         for j in range(best - 1):
             ib = np.argwhere(ixb == j)
             time_deriv[ib] = A[j + 1]

--- a/ow_calibration/fit_cond/fit_cond.py
+++ b/ow_calibration/fit_cond/fit_cond.py
@@ -558,9 +558,6 @@ def fit_cond(x, y, n_err, lvcov, *args):
             elif setbreaks:
                 # E stays fixed if breaks are specified
                 A, residual = brk_pt_fit(xf, yf, w_i, breaks)
-                print(A)
-                print(residual)
-                input("**")
 
             else:
                 # give an initial guess as the fitted break points to speed up calculation

--- a/ow_calibration/fit_cond/fit_cond_test.py
+++ b/ow_calibration/fit_cond/fit_cond_test.py
@@ -72,7 +72,13 @@ class FitCondTestCase(unittest.TestCase):
                     self.assertAlmostEqual(python_test[6][i, j], self.sta_rms[i, j], 12,
                                            "rms is incorrect")
 
-        self.assertEqual(python_test[7], self.ndf, "degrees of freeodm is incorrect")
+        self.assertEqual(python_test[7], self.ndf, "degrees of freedom is incorrect")
+
+    def test_something(self):
+
+        python_test = fit_cond(self.in_x, self.in_y, self.in_err,
+                               self.in_cov, 'breaks', np.array([0.3, 0.7]), 'max_no_breaks', 4)
+        #print(python_test)
 
 
 if __name__ == '__main__':

--- a/ow_calibration/fit_cond/fit_cond_test.py
+++ b/ow_calibration/fit_cond/fit_cond_test.py
@@ -74,11 +74,17 @@ class FitCondTestCase(unittest.TestCase):
 
         self.assertEqual(python_test[7], self.ndf, "degrees of freedom is incorrect")
 
-    def test_something(self):
+    def test_fixed_breaks(self):
+        """
+        Check that we can run this function with set break points
+        :return: nothing
+        """
+        print("Testing that fit_cond returns values when using fixed breaks")
 
         python_test = fit_cond(self.in_x, self.in_y, self.in_err,
                                self.in_cov, 'breaks', np.array([0.3, 0.7]), 'max_no_breaks', 4)
-        #print(python_test)
+
+        self.assertEqual(python_test.__len__(), 10, "should return 10 outputs")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I noticed, during some testing, that fit_cond was not running correctly when we allocated specific break points.

It now runs, but on close inspection, I have found that brk_pt_fit returns some odd values.

It turns out that, purely by chance, during some linear algebra steps, the first initial guess for solving the system is too close to the eigenvalue. This means that both matlab and python return a "best guess". The values are close, but not exactly the same.

I have changed the linear algebra solver so that the user receives a warning if the solver has had to make a "best guess"