### PR TITLE
ARGODEV-270: Line seperation in vertical averaged salinity

### DIFF
--- a/pyowc/plot/plots.py
+++ b/pyowc/plot/plots.py
@@ -593,7 +593,7 @@ def cal_sal_curve_plot(sal, cal_sal, cal_sal_err, sta_sal, sta_sal_err, sta_mean
 
         # add line at x=1 to help operators
 
-        plt.plot([-1000, 1000], [1, 1], color=(0, 0, 0), linewidth=3)
+        plt.plot([-1000, 1000], [1, 1], color=(0, 0, 0), linewidth=1.8)
         plt.xlim((np.nanmin(profile_no), np.nanmax(profile_no)))
 
         plt.legend()
@@ -616,7 +616,7 @@ def cal_sal_curve_plot(sal, cal_sal, cal_sal_err, sta_sal, sta_sal_err, sta_mean
 
         # add line at x=0 to help operators
 
-        plt.plot([-1000, 1000], [0, 0], color=(0, 0, 0), linewidth=3)
+        plt.plot([-1000, 1000], [0, 0], color=(0, 0, 0), linewidth=1.8)
         plt.xlim((np.nanmin(profile_no), np.nanmax(profile_no)))
 
         plt.legend()

--- a/pyowc/plot/plots.py
+++ b/pyowc/plot/plots.py
@@ -580,7 +580,7 @@ def cal_sal_curve_plot(sal, cal_sal, cal_sal_err, sta_sal, sta_sal_err, sta_mean
         plt.figure(1)
         plt.subplot(211)
 
-        plt.plot(profile_no[0], pcond_factor[0], color=(0, 1, 0), linestyle='-', linewidth=1)
+        plt.plot(profile_no[0], pcond_factor[0], color=(0, 1, 0), linestyle='-', linewidth=2)
         good = np.argwhere(np.isfinite(sta_mean))
         plt.plot(profile_no[0, good[:, 1]], sta_mean[0, good[:, 1]],
                  color=(1, 0, 0), linestyle='-', linewidth=1,
@@ -591,6 +591,11 @@ def cal_sal_curve_plot(sal, cal_sal, cal_sal_err, sta_sal, sta_sal_err, sta_mean
         plt.errorbar(profile_no[0], pcond_factor[0], yerr=pcond_factor_err[0],
                      color=(0, 1, 0), linestyle='', capsize=2, label='1 x cal error')
 
+        # add line at x=1 to help operators
+
+        plt.plot([-1000, 1000], [1, 1], color=(0, 0, 0), linewidth=3)
+        plt.xlim((np.nanmin(profile_no), np.nanmax(profile_no)))
+
         plt.legend()
         plt.ylabel('r')
         plt.title(float_name +
@@ -600,7 +605,7 @@ def cal_sal_curve_plot(sal, cal_sal, cal_sal_err, sta_sal, sta_sal_err, sta_mean
         plt.subplot(212)
         plt.figure(1)
 
-        plt.plot(profile_no[0], avg_sal_offset, color=(0, 1, 0), linestyle='-', linewidth=1)
+        plt.plot(profile_no[0], avg_sal_offset, color=(0, 1, 0), linestyle='-', linewidth=2)
         good = np.argwhere(np.isfinite(avg_sta_offset))
         plt.plot(profile_no[0, good[:, 0]], avg_sta_offset[good[:, 0]],
                  color=(1, 0, 0), linestyle='-', linewidth=1, label='1-1 profile fit')
@@ -608,6 +613,11 @@ def cal_sal_curve_plot(sal, cal_sal, cal_sal_err, sta_sal, sta_sal_err, sta_mean
                      color=(0, 0, 1), linestyle='', capsize=2, label='2 x cal error')
         plt.errorbar(profile_no[0], avg_sal_offset, yerr=avg_sal_offset_err,
                      color=(0, 1, 0), linestyle='', capsize=2, label='1 x cal error')
+
+        # add line at x=0 to help operators
+
+        plt.plot([-1000, 1000], [0, 0], color=(0, 0, 0), linewidth=3)
+        plt.xlim((np.nanmin(profile_no), np.nanmax(profile_no)))
 
         plt.legend()
         plt.ylabel(r'$\Delta$ S')


### PR DESCRIPTION
# Issue
[ARGODEV-270](https://jira.ceh.ac.uk/browse/ARGODEV-270)
[Issue 29](https://github.com/euroargodev/User-Acceptance-Test-Python-version-of-the-OWC-tool/issues/29)

# Symptom
Black line in vertical averaged salinity plot was not appearing. This line assist DMQC operators visualise the data

# Problem
Line had not been added to the plots

# Solution
Add the line!