### PR TITLE
Kamwal/mapped diff

### DIFF
--- a/pyowc/calibration.py
+++ b/pyowc/calibration.py
@@ -398,8 +398,9 @@ def update_salinity_mapping(float_dir, config, float_name):
                             # Need to check for statistical outliers
                             mean_sal = np.mean(hist_sal)
                             signal_sal = signal_variance(hist_sal)
-                            outlier = np.argwhere(np.abs(hist_sal - mean_sal) /
-                                                  np.sqrt(signal_sal) > 3)
+                            outlier1 = np.argwhere(np.abs(hist_sal - mean_sal) /
+                                                   np.sqrt(signal_sal) > 3)
+                            outlier = outlier1[:, 0]
 
                             # remove the statstical outliers
                             if outlier.__len__() > 0:

--- a/pyowc/calibration.py
+++ b/pyowc/calibration.py
@@ -544,8 +544,8 @@ def update_salinity_mapping(float_dir, config, float_name):
     la_profile_no = la_profile_no[sorted_profile_index]
 
     if selected_hist.__len__() > 0:
-        ind = selected_hist[:, 2].argsort()
-        selected_hist = selected_hist[ind, :]
+        selected_hist_1 = np.array(sorted(selected_hist, key=lambda x: x[2]))
+    selected_hist = selected_hist_1
 
     # define the saving location
     save_location = os.path.sep.join([config['FLOAT_MAPPED_DIRECTORY'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy>=1.18
 scipy>=1.1
 gsw>=3.3.1
+pymatreader>=0.0
 
 # For plotting functionalities:
 matplotlib>=3.1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     name='pyowc',
     version='0.1.1',
     author="pyowc Developers",
-    author_email="edsmall@bodc.ac.uk",
+    author_email="argo@bodc.ac.uk",
     description="OWC salinity calibration in Python",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     name='pyowc',
     version='0.1.1',
     author="pyowc Developers",
-    author_email="argo@bodc.ac.uk",
+    author_email="edsmall@bodc.ac.uk",
     description="OWC salinity calibration in Python",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Task or Issue
Issue 1 - Wrong sorting of selected_hist parameter in mapping.mat file

Issue 2- Relatively large differences between Matlab and Python output in la_mapped_sal and la_mapped_errors.

## Symptom
Issue 1 - The longitude and latitude selected for each float profile was in random order compared with its Maltab version. 

Issue 2- The differences between matlab and python version in  la_mapped_sal and la_mapped_errors were in order on 10x-2 for example float WMO 3901960.

## Problem
Issue 1 - This parameter is saved to mapped.mat file. This parameter is used in  calc_piecewisefit function. However, this issue should not affect the calculations. The fix was undertaken to represent the same output as in Matlab version.

Issue 2- the problem was wrong size of variable "outliner", instead size 2x1 it has size 2x2. In result, too much data and wrongly selected data were excludes from historical data what lead to increase an error in further statistical calculations.

## Solution
Issue 1 - The "argsort" function was replaced by the built in python "sorted" function.

Issue 2- The size of outliner has been corrected to 2x1.