### PR TITLE
Skip levels with all nan data

### DIFF
--- a/pyowc/core/finders.py
+++ b/pyowc/core/finders.py
@@ -697,6 +697,9 @@ def find_10thetas(sal, ptmp, pres, la_ptmp,
     # select the best 10 theta levels
 
     for i in range(no_levels):
+        # ensure there is a non-nan minimum value to find
+        if np.all(np.isnan(var_sal_tlevels)):
+            continue
         min_theta_index = np.argwhere(var_sal_tlevels == np.nanmin(var_sal_tlevels))[0, 0]
         index[i, :] = theta_level_indices[min_theta_index, :]
         t_levels[i] = theta_levels[min_theta_index]


### PR DESCRIPTION
In some scenarios, `find_10thetas` was failing as it encountered a slice of data that was all `nan`s. It couldn't find a minimum value in this, so it threw and exceptions. The fix is to reinstate a check that it's not all `nan`s and skip if it is.